### PR TITLE
Feature/setup travis ci with GitHub #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,16 @@ language: java
 #sudo: required only required when using docker or when you are using sudo commands
 sudo: false
 
-#cache:
-#  directories:
-#    - $HOME/.m2
+cache:
+  directories:
+    - $HOME/.m2
 
 jdk:
   - oraclejdk8
-#  - oraclejdk9
 
 #services:
 #  - docker
 
-
-#branches:
-#  only:
-#    - master
-#  except:
-#    - Nick
 
 notifications:
   email: false
@@ -34,12 +27,13 @@ notifications:
 #    on_success: change
 #    on_failure: always
 
-install:
+install: #forcing a maven install instead of the default maven wrapper install
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 #any console commands can be executed here
 script:
   - echo this is an example
   - ls
+  - ls target
   - mvn -Dtest=* test
   - echo $TRAVIS_JDK_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache:
 jdk:
   - oraclejdk8
 
-#services:
-#  - docker
 
 
 notifications:

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,27 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<configuration>
+					<failOnViolation>false</failOnViolation> <!-- this is actually true by default, but can be disabled -->
+					<printFailingErrors>true</printFailingErrors>
+					<rulesets>
+						<!-- Two rule sets that come bundled with PMD -->
+						<ruleset>/rulesets/java/basic.xml</ruleset>
+						<ruleset>/rulesets/java/braces.xml</ruleset>
+						<ruleset>/rulesets/java/naming.xml</ruleset>
+					</rulesets>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,15 +55,56 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.8</version>
 				<configuration>
 					<failOnViolation>false</failOnViolation> <!-- this is actually true by default, but can be disabled -->
 					<printFailingErrors>true</printFailingErrors>
 					<rulesets>
-						<!-- Two rule sets that come bundled with PMD -->
 						<ruleset>/rulesets/java/basic.xml</ruleset>
 						<ruleset>/rulesets/java/braces.xml</ruleset>
 						<ruleset>/rulesets/java/naming.xml</ruleset>
 					</rulesets>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>pmd</goal>
+							<goal>check</goal>
+							<goal>cpd</goal>
+							<goal>cpd-check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<configuration>
+							<!--<configLocation>checkstyle.xml</configLocation>-->
+							<failOnViolation>false</failOnViolation>
+							<encoding>UTF-8</encoding>
+							<consoleOutput>true</consoleOutput>
+							<failsOnError>false</failsOnError>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>3.0.5</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Low</threshold>
+					<xmlOutput>true</xmlOutput>
 				</configuration>
 				<executions>
 					<execution>
@@ -75,6 +116,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-
 </project>


### PR DESCRIPTION
Removed the comment code that is not used for explenation
Added an explenation to why the install is used

Added the following plugins:
- pmd
- cpd
- checkstyle
- findbugs

Added version number to pmd.
Failing on violation is turned off to speed up building.
The violations are stored in a file in the target map.
Caching is enabled for faster building.
Added the "ls target" command to show everything in the target directory.
